### PR TITLE
remove "files" field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Inferno wrapper around PopperJS.",
   "main": "dist/cjs/index.js",
   "umd:main": "dist/umd/index.js",
-  "module": "lib/index.js",
+  "module": "src/index.js",
   "types": "inferno-popper.d.ts",
   "scripts": {
     "test": "echo ok",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,6 @@
   "umd:main": "dist/umd/index.js",
   "module": "lib/index.js",
   "types": "inferno-popper.d.ts",
-  "files": [
-    "dist",
-    "lib",
-    "inferno-popper.d.ts"
-  ],
   "scripts": {
     "test": "echo ok",
     "test-browser": "npm run build-test && node test/browser/server.js",


### PR DESCRIPTION
Hi,

Just wanted to update to the newest version, and had some issues with it.
after `npm install` the files in the node_modules folder contained imports that can not be resolved:
e.g. 

> import _objectWithoutProperties from "/Users/jhsware/node/lerna-inferno-modules/packages/inferno-popper/node_modules/@babel/runtime/helpers/esm/objectWithoutProperties";

see this link for details: https://npm.runkit.com/inferno-popper/lib/Manager.js?t=1540277616755
i have removed the "files" field from the package.json, and npm will now import inferno-popper without changing or messing up the source code.

